### PR TITLE
store raw gpu frequency from sysfs

### DIFF
--- a/collectors/gpufreq.cpp
+++ b/collectors/gpufreq.cpp
@@ -54,12 +54,8 @@ bool GPUFreqCollector::parse(const char* buffer)
             freq = 0;
         }
         // on qcom, they store hz, not mhz... so transform to mhz
-        if (freq > ONE_MILLION)
-        {
-            freq /= ONE_MILLION;
-        }
     }
-    add("gpufreq", freq * 1000);
+    add("gpufreq");
 
     return true;
 }


### PR DESCRIPTION
Assuming the unit of frequency based on number of zeros
could be misleading.