### PR TITLE
Remove stray `debug.cpp` reference in build system

### DIFF
--- a/android/gradle/layer_android/CMakeLists.txt
+++ b/android/gradle/layer_android/CMakeLists.txt
@@ -9,7 +9,6 @@ set(LAYER_SOURCES
     ${PROJECT_DIR}/interface.cpp
     ${PROJECT_DIR}/collectors/collector_utility.cpp
     ${PROJECT_DIR}/collectors/cputemp.cpp
-    ${PROJECT_DIR}/collectors/debug.cpp
     ${PROJECT_DIR}/collectors/rusage.cpp
     ${PROJECT_DIR}/collectors/streamline.cpp
     ${PROJECT_DIR}/collectors/streamline_annotate.cpp


### PR DESCRIPTION
Android build with gradle complains about a missing `collectors/debug.cpp`.

This is due to a lingering reference that slipped through
`d40e02e08460cab77690706013c9d54892ade602` when the debug plugin was removed.

Reported-by: Amigo Zhen <Amigo.Zhen@arm.com>