### PR TITLE
Fix building for Android

### DIFF
--- a/android/gradle/build.gradle
+++ b/android/gradle/build.gradle
@@ -4,10 +4,11 @@ buildscript {
     
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -18,7 +19,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/android/gradle/collector_android/CMakeLists.txt
+++ b/android/gradle/collector_android/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.6.0)
+project(libcollector)
 
 set(PROJECT_DIR ${CMAKE_SOURCE_DIR}/../../../)
-set(THIRD_PARTY_DIR ${PROJECT_DIR}/thirdparty)
+set(THIRD_PARTY_DIR ${PROJECT_DIR}/external)
 set(SOURCE_DIR ${PROJECT_DIR}/collectors)
 
 add_definitions(-DANDROID_STL="c++_shared")
@@ -23,17 +24,15 @@ set(COLLECTOR_SOURCES
     ${SOURCE_DIR}/procfs_stat.cpp
     ${SOURCE_DIR}/hwcpipe.cpp
     ${SOURCE_DIR}/mali_counters.cpp
-    ${THIRD_PARTY_DIR}/jsoncpp/json_writer.cpp
-    ${THIRD_PARTY_DIR}/jsoncpp/json_reader.cpp
-    ${THIRD_PARTY_DIR}/jsoncpp/json_value.cpp)
+    ${THIRD_PARTY_DIR}/jsoncpp/src/lib_json/json_writer.cpp
+    ${THIRD_PARTY_DIR}/jsoncpp/src/lib_json/json_reader.cpp
+    ${THIRD_PARTY_DIR}/jsoncpp/src/lib_json/json_value.cpp)
 
 set(BURROW_SOURCES ${PROJECT_DIR}/burrow.cpp)
 
 set(TARGET_INCLUDE_DIRS
     ${SOURCE_DIR}
-    ${THIRD_PARTY_DIR}
-    ${THIRD_PARTY_DIR}/jsoncpp
-    ${THIRD_PARTY_DIR}/jsoncpp/json
+    ${THIRD_PARTY_DIR}/jsoncpp/include
     ${PROJECT_DIR})
 
 include_directories(${TARGET_INCLUDE_DIRS})

--- a/android/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 22 16:52:23 CEST 2018
+#Tue Aug 09 19:25:54 CEST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/android/gradle/layer_android/CMakeLists.txt
+++ b/android/gradle/layer_android/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.6.0)
+project(layer_android)
 
 set(PROJECT_DIR ${CMAKE_SOURCE_DIR}/../../../)
 
@@ -22,17 +23,16 @@ set(LAYER_SOURCES
     ${PROJECT_DIR}/collectors/mali_counters.cpp
     ${PROJECT_DIR}/collectors/ferret.cpp
     ${PROJECT_DIR}/layer/vulkan_layer.cpp
-    ${PROJECT_DIR}/thirdparty/jsoncpp/json_reader.cpp
-    ${PROJECT_DIR}/thirdparty/jsoncpp/json_value.cpp
-    ${PROJECT_DIR}/thirdparty/jsoncpp/json_writer.cpp)
+    ${PROJECT_DIR}/external/jsoncpp/src/lib_json/json_reader.cpp
+    ${PROJECT_DIR}/external/jsoncpp/src/lib_json/json_value.cpp
+    ${PROJECT_DIR}/external/jsoncpp/src/lib_json/json_writer.cpp)
 
 
 set(TARGET_INCLUDE_DIRS
     PUBLIC  ${PROJECT_DIR}
     PRIVATE ${PROJECT_DIR}/collectors
-    PUBLIC  ${PROJECT_DIR}/thirdparty
-    PRIVATE ${PROJECT_DIR}/thirdparty/jsoncpp
-    PRIVATE ${PROJECT_DIR}/thirdparty/Vulkan-Headers/include
+    PRIVATE ${PROJECT_DIR}/external/jsoncpp/include
+    PRIVATE ${PROJECT_DIR}/external/Vulkan-Headers/include
     PRIVATE ${PROJECT_DIR}/layer)
 
 include_directories(${TARGET_INCLUDE_DIRS})

--- a/android/gradle/layer_android/build.gradle
+++ b/android/gradle/layer_android/build.gradle
@@ -6,8 +6,6 @@ android {
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 28
-        versionCode 1
-        versionName "1.0"
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++11 -frtti -fexceptions -Wno-cast-calling-convention"
@@ -39,7 +37,6 @@ android {
                             "-DCMAKE_BUILD_TYPE=Release"
                 }
             }
-            debuggable true
             signingConfig signingConfigs.debug
             jniDebuggable true
         }

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -37,26 +37,25 @@ LOCAL_SRC_FILES 	:=  \
                     ../../collectors/procfs_stat.cpp \
                     ../../collectors/hwcpipe.cpp \
                     ../../collectors/mali_counters.cpp \
-                    ../../thirdparty/jsoncpp/json_writer.cpp \
-                    ../../thirdparty/jsoncpp/json_reader.cpp \
-                    ../../thirdparty/jsoncpp/json_value.cpp
+                    ../../external/jsoncpp/src/lib_json/json_writer.cpp \
+                    ../../external/jsoncpp/src/lib_json/json_reader.cpp \
+                    ../../external/jsoncpp/src/lib_json/json_value.cpp
 
 LOCAL_C_INCLUDES 	:= \
                     $(LOCAL_PATH)/../../collectors \
-                    $(LOCAL_PATH)/../../thirdparty \
-                    $(LOCAL_PATH)/../../thirdparty/jsoncpp \
-                    $(LOCAL_PATH)/../../thirdparty/jsoncpp/json \
+                    $(LOCAL_PATH)/../../external/jsoncpp/include \
                     $(LOCAL_PATH)/../..
 
 LOCAL_CFLAGS 		:= -O3 -frtti -D__arm__ -D__gnu_linux__
 LOCAL_CPPFLAGS          += -std=c++11
+LOCAL_CPP_FEATURES      += exceptions
 
 ifeq ($(TARGET_ARCH_ABI),x86)
 LOCAL_CFLAGS		+= -Wno-attributes
 endif
 
-LOCAL_STATIC_LIBRARIES := android_native_app_glue
-LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../../thirdparty/
+LOCAL_STATIC_LIBRARIES :=
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../../external/
 
 include $(BUILD_STATIC_LIBRARY)
 
@@ -65,13 +64,12 @@ LOCAL_MODULE_FILENAME := burrow
 LOCAL_SRC_FILES := ../../burrow.cpp
 LOCAL_C_INCLUDES := \
                     $(LOCAL_PATH)/../../collectors \
-                    $(LOCAL_PATH)/../../thirdparty \
-                    $(LOCAL_PATH)/../../thirdparty/jsoncpp \
-                    $(LOCAL_PATH)/../../thirdparty/jsoncpp/json \
+                    $(LOCAL_PATH)/../../external/jsoncpp/include\
                     $(LOCAL_PATH)/../..
 
 LOCAL_LDLIBS    := -L$(SYSROOT)/usr/lib -llog -latomic
 
-LOCAL_STATIC_LIBRARIES := android_native_app_glue collector_android
+LOCAL_STATIC_LIBRARIES := collector_android
+LOCAL_CPP_FEATURES     += exceptions
 
 include $(BUILD_EXECUTABLE)

--- a/android/jni/Application.mk
+++ b/android/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_PLATFORM := android-18
-APP_ABI := armeabi armeabi-v7a arm64-v8a x86
+APP_PLATFORM := android-19
+APP_ABI := armeabi-v7a arm64-v8a x86
 APP_PROJECT_PATH := $(call my-dir)/..
-APP_STL := gnustl_static
+APP_STL := c++_static


### PR DESCRIPTION
Fix building for Android

 - Make it possible to build with ndk-build
-  Update jsoncpp to the latest version, and fix include and src paths
-  Set the minimum android version to 19, to allow building with the latest ndk (r25).
-  Update to newer gradle version