### PR TITLE
add option for perf event attr inherit

### DIFF
--- a/collectors/perf.hpp
+++ b/collectors/perf.hpp
@@ -50,6 +50,7 @@ struct event {
     bool booker_ci;  // default is false
     bool cspmu;
     std::string device; // default is ""
+    uint32_t inherited; 
 };
 
 class event_context


### PR DESCRIPTION
From Heinrich Zhou: I want to add an option to control if perf event incorporates child thread CPU load to main thread, if child thread's counter is not created.