### PR TITLE
add option for perf event attr inherit

### DIFF
--- a/collectors/perf.cpp
+++ b/collectors/perf.cpp
@@ -82,9 +82,12 @@ static inline uint64_t makeup_booker_ci_config(int nodetype, int eventid, int by
 PerfCollector::PerfCollector(const Json::Value& config, const std::string& name) : Collector(config, name)
 {
     struct event leader = {"CPUCycleCount", PERF_TYPE_HARDWARE, PERF_COUNT_HW_CPU_CYCLES};
-    mEvents.push_back(leader);
 
     mSet = mConfig.get("set", -1).asInt();
+    mInherit = mConfig.get("inherit", 1).asInt();    
+    
+    leader.inherited = mInherit;
+    mEvents.push_back(leader);
 
     if ((0 <= mSet) && (mSet <= 3))
     {
@@ -114,6 +117,7 @@ PerfCollector::PerfCollector(const Json::Value& config, const std::string& name)
             e.booker_ci = item.get("booker-ci", 0).asInt();
             e.cspmu = item.get("CSPMU", 0).asInt();
             e.device = item.get("device", "").asString();
+            e.inherited = mInherit;
 
             if (e.booker_ci)
             {   // booker-ci counter
@@ -213,7 +217,7 @@ static int add_event(const struct event &e, int tid, int cpu, int group = -1)
     pe.config = e.config;
     pe.config1 = (e.len == hw_cnt_length::b32) ? 0 : 1;
     pe.disabled = 1;
-    pe.inherit = 1;
+    pe.inherit = e.inherited;
     pe.exclude_user = e.exc_user;
     pe.exclude_kernel = e.exc_kernel;
     pe.exclude_hv = 0;

--- a/collectors/perf.hpp
+++ b/collectors/perf.hpp
@@ -50,6 +50,7 @@ struct event {
     bool booker_ci;  // default is false
     bool cspmu;
     std::string device; // default is ""
+    uint32_t inherited; 
 };
 
 class event_context
@@ -107,6 +108,7 @@ private:
 
 private:
     int mSet = -1;
+    int mInherit = 1;
     bool mAllThread = true;
     std::vector<struct event> mEvents;
     std::vector<struct event> mBookerEvents;

--- a/collectors/perf.hpp
+++ b/collectors/perf.hpp
@@ -50,7 +50,7 @@ struct event {
     bool booker_ci;  // default is false
     bool cspmu;
     std::string device; // default is ""
-    uint32_t inherited; 
+    uint32_t inherited; // default is 1
 };
 
 class event_context


### PR DESCRIPTION
From Heinrich Zhou: I want to add an option to control if perf event incorporates child thread CPU load to main thread, if child thread's counter is not created.