### PR TITLE
Add collect_scope_start/stop to measure perf counters for a code fragment

### DIFF
--- a/collectors/perf.cpp
+++ b/collectors/perf.cpp
@@ -475,27 +475,27 @@ bool PerfCollector::collect_scope_stop(int64_t now, uint16_t func_id) {
     for (perf_thread &t : mReplayThreads) {
         snap_start = t.eventCtx.last_snap;
         snap_stop = t.eventCtx.collect_scope(now, func_id, true);
-        t.eventCtx.update_data_perapi(func_id, snap_start, snap_stop, t.mResultsPerThread);
+        t.eventCtx.update_data_scope(func_id, snap_start, snap_stop, t.mResultsPerThread);
     }
     for (perf_thread &t : mBgThreads) {
         snap_start = t.eventCtx.last_snap;
         snap_stop = t.eventCtx.collect_scope(now, func_id, true);
-        t.eventCtx.update_data_perapi(func_id, snap_start, snap_stop, t.mResultsPerThread);
+        t.eventCtx.update_data_scope(func_id, snap_start, snap_stop, t.mResultsPerThread);
     }
     for (perf_thread &t : mMultiPMUThreads) {
         snap_start = t.eventCtx.last_snap;
         snap_stop = t.eventCtx.collect_scope(now, func_id, true);
-        t.eventCtx.update_data_perapi(func_id, snap_start, snap_stop, t.mResultsPerThread);
+        t.eventCtx.update_data_scope(func_id, snap_start, snap_stop, t.mResultsPerThread);
     }
     for (perf_thread &t : mBookerThread) {
         snap_start = t.eventCtx.last_snap;
         snap_stop = t.eventCtx.collect_scope(now, func_id, true);
-        t.eventCtx.update_data_perapi(func_id, snap_start, snap_stop, t.mResultsPerThread);
+        t.eventCtx.update_data_scope(func_id, snap_start, snap_stop, t.mResultsPerThread);
     }
     for (perf_thread &t : mCSPMUThreads) {
         snap_start = t.eventCtx.last_snap;
         snap_stop = t.eventCtx.collect_scope(now, func_id, true);
-        t.eventCtx.update_data_perapi(func_id, snap_start, snap_stop, t.mResultsPerThread);
+        t.eventCtx.update_data_scope(func_id, snap_start, snap_stop, t.mResultsPerThread);
     }
     return false;
 }

--- a/collectors/perf.hpp
+++ b/collectors/perf.hpp
@@ -83,7 +83,7 @@ public:
             result[mCounters[i].name].push_back(snap.values[i]);
     }
 
-    inline void update_data_perapi(uint16_t func_id, struct snapshot &snap_start, struct snapshot &snap_end, CollectorValueResults &result)
+    inline void update_data_scope(uint16_t func_id, struct snapshot &snap_start, struct snapshot &snap_end, CollectorValueResults &result)
     {
         for (unsigned int i = 0; i < mCounters.size(); i++) {
             std::string name = mCounters[i].name + ":" + std::to_string(func_id);
@@ -119,10 +119,7 @@ public:
     virtual bool postprocess(const std::vector<int64_t>& timing) override;
     virtual void summarize() override;
 
-    /// @brief Collector functions for perapi perf instrumentations.
-    /// @param now Current time in milliseconds.
-    /// @param func_id The function id.
-    /// @return
+    /// Collector functions for perapi perf instrumentations.
     virtual bool collect_scope_start(int64_t now, uint16_t func_id);
     virtual bool collect_scope_stop(int64_t now, uint16_t func_id);
 
@@ -149,9 +146,9 @@ private:
             eventCtx.update_data(snap, mResultsPerThread);
         }
 
-        void update_data_perapi(uint16_t func_id, struct snapshot& snap_start, struct snapshot& snap_end)
+        void update_data_scope(uint16_t func_id, struct snapshot& snap_start, struct snapshot& snap_end)
         {
-            eventCtx.update_data_perapi(func_id, snap_start, snap_end, mResultsPerThread);
+            eventCtx.update_data_scope(func_id, snap_start, snap_end, mResultsPerThread);
         }
 
         void clear()

--- a/collectors/perf.hpp
+++ b/collectors/perf.hpp
@@ -36,6 +36,17 @@ enum cmn_node_type
     CMN_TYPE_WP = 0x7770,
 };
 
+enum collect_scope_flags: int32_t
+{
+    COLLECT_NOOP = 0x00,
+    COLLECT_ALL_THREADS = 0x01,
+    COLLECT_REPLAY_THREADS = 0x01 << 1,
+    COLLECT_BG_THREADS = 0x01 << 2,
+    COLLECT_MULTI_PMU_THREADS = 0x01 << 3,
+    COLLECT_BOOKER_THREADS = 0x01 << 4,
+    COLLECT_CSPMU_THREADS = 0x01 << 5,
+};
+
 struct snapshot {
     snapshot() : size(0) {}
 
@@ -147,8 +158,8 @@ public:
     virtual void summarize() override;
 
     /// Collector functions for perapi perf instrumentations.
-    virtual bool collect_scope_start(int64_t now, uint16_t func_id);
-    virtual bool collect_scope_stop(int64_t now, uint16_t func_id);
+    virtual bool collect_scope_start(int64_t now, uint16_t func_id, int32_t flags);
+    virtual bool collect_scope_stop(int64_t now, uint16_t func_id, int32_t flags);
 
   private:
     void create_perf_thread();
@@ -163,6 +174,7 @@ private:
     std::map<int, std::vector<struct event>> mMultiPMUEvents;
     std::map<int, std::vector<struct event>> mCSPMUEvents;
     std::map<std::string, std::vector<struct timespec>> mClocks; // device_name -> clock_vector
+    int last_collect_scope_flags = 0;
 
     struct perf_thread
     {

--- a/interface.cpp
+++ b/interface.cpp
@@ -465,13 +465,13 @@ void Collection::collect_scope_start(uint16_t label) {
 
 void Collection::collect_scope_stop(uint16_t label) {
     // A collect_scope_start and collect_scope_end pair is considered as one sample.
-    // Timing is calculated from the start of the scope to the end of the scope.
     if (!mScopeStarted) {
         DBG_LOG("WARNING: collect_scope_stop called without a corresponding collect_scope_start.\n");
         return;
     }
     const int64_t now = getTime();
-    mTiming.push_back(now - mScopeStartTime);
+    // Timing is ignored to avoid extreme large json outputs.
+    // mTiming.push_back(now - mScopeStartTime);
     for (Collector* c : mRunning)
     {
         if (!c->isThreaded())

--- a/interface.cpp
+++ b/interface.cpp
@@ -450,20 +450,20 @@ void Collection::collect(std::vector<int64_t> custom)
     }
 }
 
-void Collection::collect_scope_start(uint16_t label) {
+void Collection::collect_scope_start(uint16_t label, int32_t flags) {
     const int64_t now = getTime();
     mScopeStartTime = now;
     for (Collector* c : mRunning)
     {
         if (!c->isThreaded())
         {
-            c->collect_scope_start(now, label);
+            c->collect_scope_start(now, label, flags);
         }
     }
     mScopeStarted = true;
 }
 
-void Collection::collect_scope_stop(uint16_t label) {
+void Collection::collect_scope_stop(uint16_t label, int32_t flags) {
     // A collect_scope_start and collect_scope_end pair is considered as one sample.
     if (!mScopeStarted) {
         DBG_LOG("WARNING: collect_scope_stop called without a corresponding collect_scope_start.\n");
@@ -476,7 +476,7 @@ void Collection::collect_scope_stop(uint16_t label) {
     {
         if (!c->isThreaded())
         {
-            c->collect_scope_stop(now, label);
+            c->collect_scope_stop(now, label, flags);
         }
     }
     mScopeStarted = false;

--- a/interface.cpp
+++ b/interface.cpp
@@ -450,6 +450,28 @@ void Collection::collect(std::vector<int64_t> custom)
     }
 }
 
+void Collection::collect_scope_start(uint16_t func_id) {
+    const int64_t now = getTime();
+    for (Collector* c : mRunning)
+    {
+        if (!c->isThreaded())
+        {
+            c->collect_scope_start(now, func_id);
+        }
+    }
+}
+
+void Collection::collect_scope_stop(uint16_t func_id) {
+    const int64_t now = getTime();
+    for (Collector* c : mRunning)
+    {
+        if (!c->isThreaded())
+        {
+            c->collect_scope_stop(now, func_id);
+        }
+    }
+}
+
 Json::Value Collection::results()
 {
     Json::Value results;

--- a/interface.hpp
+++ b/interface.hpp
@@ -90,6 +90,8 @@ public:
     virtual bool stop() { mCollecting = false; return true; }
     virtual bool postprocess(const std::vector<int64_t>& timing);
     virtual bool collect( int64_t ) = 0;
+    virtual bool collect_scope_start( int64_t now, uint16_t func_id) {return true; };
+    virtual bool collect_scope_stop( int64_t now, uint16_t func_id) { return true; };
     virtual bool collecting() const { return mCollecting; }
     virtual const std::string& name() const { return mName; }
     virtual bool available() = 0;
@@ -251,6 +253,14 @@ public:
     /// Collect one data point. If result is specified, this is used to specify a custom
     /// result value.
     void collect(std::vector<int64_t> custom = std::vector<int64_t>());
+
+    /// Sample periodical data for per function instrumentation. Call start before the actual code
+    /// to be tested. Currently only used for perf collector.
+    void collect_scope_start(uint16_t func_id);
+
+    /// Sample periodical data for per function instrumentation. Call after before the actual code
+    /// to be tested. Currently only used for perf collector.
+    void collect_scope_stop(uint16_t func_id);
 
     /// Get the results as JSON
     Json::Value results();

--- a/interface.hpp
+++ b/interface.hpp
@@ -90,8 +90,8 @@ public:
     virtual bool stop() { mCollecting = false; return true; }
     virtual bool postprocess(const std::vector<int64_t>& timing);
     virtual bool collect( int64_t ) = 0;
-    virtual bool collect_scope_start( int64_t now, uint16_t func_id) {return true; };
-    virtual bool collect_scope_stop( int64_t now, uint16_t func_id) { return true; };
+    virtual bool collect_scope_start( int64_t now, uint16_t func_id, int flags ) {return true; };
+    virtual bool collect_scope_stop( int64_t now, uint16_t func_id, int flags ) { return true; };
     virtual bool collecting() const { return mCollecting; }
     virtual const std::string& name() const { return mName; }
     virtual bool available() = 0;
@@ -256,11 +256,11 @@ public:
 
     /// Sample periodical data for per API instrumentation. Call this method before the payload
     /// execution. Currently only used for perf collector.
-    void collect_scope_start(uint16_t label);
+    void collect_scope_start(uint16_t label, int32_t flags);
 
     /// Sample periodical data for per API instrumentation. Call this method after the payload
     /// execution. Currently only used for perf collector.
-    void collect_scope_stop(uint16_t label);
+    void collect_scope_stop(uint16_t label, int32_t flags);
 
     /// Get the results as JSON
     Json::Value results();

--- a/interface.hpp
+++ b/interface.hpp
@@ -254,13 +254,13 @@ public:
     /// result value.
     void collect(std::vector<int64_t> custom = std::vector<int64_t>());
 
-    /// Sample periodical data for per function instrumentation. Call start before the actual code
-    /// to be tested. Currently only used for perf collector.
-    void collect_scope_start(uint16_t func_id);
+    /// Sample periodical data for per API instrumentation. Call this method before the payload
+    /// execution. Currently only used for perf collector.
+    void collect_scope_start(uint16_t label);
 
-    /// Sample periodical data for per function instrumentation. Call after before the actual code
-    /// to be tested. Currently only used for perf collector.
-    void collect_scope_stop(uint16_t func_id);
+    /// Sample periodical data for per API instrumentation. Call this method after the payload
+    /// execution. Currently only used for perf collector.
+    void collect_scope_stop(uint16_t label);
 
     /// Get the results as JSON
     Json::Value results();
@@ -282,5 +282,7 @@ private:
     std::vector<std::string> mCustomHeaders;
     int64_t mStartTime = 0;
     int64_t mPreviousTime = 0;
+    bool mScopeStarted = false;
+    int64_t mScopeStartTime = 0;
     bool mDebug = false;
 };


### PR DESCRIPTION
This PR adds `collect_scope_start(uint64_t label, uint32_t flags)` and `collect_scope_stop(uint64_t label, uint32_t flags)` methods to the perf collector. These methods make it easier to measure event counters involved during the execution of a code fragment. This is useful for our internal request.

## Example

```cpp
// label_A = 1
collector->collect_scope_start(label_A, COLLECT_REPLAY_THREADS);
func_A();
collector->collect_scope_stop(label_A, COLLECT_REPLAY_THREADS);

// label_B = 2
collector->collect_scope_start(label_B, COLLECT_REPLAY_THREADS);
func_B();
collector->collect_scope_stop(label_B, COLLECT_REPLAY_THREADS);
```

Then we can get results like this:
```jsonc
{
    "CCthread" : "patrace-1",
    "CCthread:ScopeNumCalls" : [ 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0 ],
    "CPUCycleCount:ScopeSum" : [ 31452, 91076, 0, 0, 0, 17832, 24730, 0, 0, 0, 0, 0, 0 ],
    "CPUCyclesKernel:ScopeSum" : [ 30764, 14779, 0, 0, 0, 17824, 7852, 0, 0, 0, 0, 0, 0 ],

  // ...
},
```
Here `CCthread:ScopeNumCalls[i]` is the total number of `collect_scope_start/stop` calls with label i, and the accumulated counter values for a specific event can be found at `<EventName>:ScopeSum[i]`.